### PR TITLE
Feat/non user namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ drafts = Message.drafts(current_user)
 messages = drafts.restore_all
 ```
 
+### Migration
+
+#### 0.5.x
+
+Starting from 0.5.x, you will be able to save drafts under a non `User` model as such:
+```
+message.save_draft(author)
+```
+
+If you are upgrading from previous versions, simply run `rails g drafting:migration` again to generate the mising migration files.
+
 ### Linking to parent instance
 
 ```ruby
@@ -99,7 +110,6 @@ message.save!
 * After doing a `save`, the draft (if there is one) will be deleted
 * The `user` argument can be nil if you don't want to distinguish between multiple users
 * Saving draft stores the data via `Marshal.dump` and `Marshal.load`. If you don't like this or need some customization, you can override the instance methods `dump_to_draft` and `load_from_draft` (see source)
-
 
 ## Development
 

--- a/drafting.gemspec
+++ b/drafting.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "generator_spec"
 end

--- a/lib/drafting/base_class_methods.rb
+++ b/lib/drafting/base_class_methods.rb
@@ -15,11 +15,19 @@ module Drafting
         unless parent_class.method_defined? :drafts
           parent_class.class_eval do
             def drafts(user)
-              Draft.where(user: user, parent: self)
+              Draft.where(
+                user: user,
+                user_type: user.try(:class).try(:name),
+                parent: self
+              )
             end
 
             def self.child_drafts(user)
-              Draft.where(user: user, parent_type: self.base_class.name)
+              Draft.where(
+                user: user,
+                user_type: user.try(:class).try(:name),
+                parent_type: self.base_class.name
+              )
             end
           end
         end

--- a/lib/drafting/draft.rb
+++ b/lib/drafting/draft.rb
@@ -1,5 +1,5 @@
 class Draft < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user, polymorphic: true
   belongs_to :parent, polymorphic: true
 
   validates_presence_of :data, :target_type

--- a/lib/drafting/instance_methods.rb
+++ b/lib/drafting/instance_methods.rb
@@ -7,7 +7,8 @@ module Drafting
 
       draft.data = dump_to_draft
       draft.target_type = self.class.name
-      draft.user = user
+      draft.user_id = user.try(:id)
+      draft.user_type = user.try(:class).try(:name)
       draft.parent = self.send(self.class.draft_parent) if self.class.draft_parent
 
       result = draft.save

--- a/lib/drafting/version.rb
+++ b/lib/drafting/version.rb
@@ -1,3 +1,3 @@
 module Drafting
-  VERSION = "0.4.2"
+  VERSION = "0.5.0"
 end

--- a/lib/generators/drafting/migration/migration_generator.rb
+++ b/lib/generators/drafting/migration/migration_generator.rb
@@ -10,6 +10,7 @@ module Drafting
 
     def create_migration_file
       migration_template 'migration.rb', 'db/migrate/drafting_migration.rb'
+      migration_template 'non_user_migration.rb', 'db/migrate/non_user_drafting_migration.rb'
     end
 
     def self.next_migration_number(dirname)

--- a/lib/generators/drafting/migration/templates/migration.rb
+++ b/lib/generators/drafting/migration/templates/migration.rb
@@ -2,13 +2,13 @@ class DraftingMigration < Drafting::MIGRATION_BASE_CLASS
   def self.up
     create_table :drafts do |t|
       t.string :target_type, null: false
-      t.references :user, polymorphic: true, index: true
+      t.references :user
       t.references :parent, polymorphic: true, index: true
       t.binary :data, limit: 16777215, null: false
       t.datetime :updated_at, null: false
     end
 
-    add_index :drafts, [:target_type]
+    add_index :drafts, [:user_id, :target_type]
   end
 
   def self.down

--- a/lib/generators/drafting/migration/templates/migration.rb
+++ b/lib/generators/drafting/migration/templates/migration.rb
@@ -2,13 +2,13 @@ class DraftingMigration < Drafting::MIGRATION_BASE_CLASS
   def self.up
     create_table :drafts do |t|
       t.string :target_type, null: false
-      t.references :user
+      t.references :user, polymorphic: true, index: true
       t.references :parent, polymorphic: true, index: true
       t.binary :data, limit: 16777215, null: false
       t.datetime :updated_at, null: false
     end
 
-    add_index :drafts, [:user_id, :target_type]
+    add_index :drafts, [:target_type]
   end
 
   def self.down

--- a/lib/generators/drafting/migration/templates/non_user_migration.rb
+++ b/lib/generators/drafting/migration/templates/non_user_migration.rb
@@ -1,0 +1,13 @@
+class NonUserDraftingMigration < Drafting::MIGRATION_BASE_CLASS
+  def self.up
+    add_column :drafts, :user_type, :string, index: true
+
+    # add in user_type for existing drafts table
+    # for migration from old version
+    Draft.update_all(user_type: 'User')
+  end
+
+  def self.down
+    remove_column :drafts, :user_type
+  end
+end

--- a/spec/drafting/class_methods_spec.rb
+++ b/spec/drafting/class_methods_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Drafting::ClassMethods do
   let(:user) { FactoryBot.create(:user) }
+  let(:admin_user) { FactoryBot.create(:admin_user) }
   let(:topic) { FactoryBot.create(:topic) }
   let(:message) { topic.messages.build user: user, content: 'foo' }
   let(:page) { Page.new title: 'First post' }
@@ -19,6 +20,15 @@ describe Drafting::ClassMethods do
 
       expect(Page.drafts(nil).count).to eq(1)
       expect(Page.drafts(nil).first).to be_a(Draft)
+    end
+
+    it 'should find Draft objects with non user' do
+      page.save_draft(admin_user)
+
+      expect(Page.drafts(admin_user).count).to eq(1)
+      expect(Page.drafts(admin_user).first).to be_a(Draft)
+
+      expect(Page.drafts(user).count).to eq(0)
     end
   end
 

--- a/spec/drafting/instance_methods_spec.rb
+++ b/spec/drafting/instance_methods_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Drafting::InstanceMethods do
   let(:user) { FactoryBot.create(:user) }
   let(:other_user) { FactoryBot.create(:user) }
+  let(:admin_user) { FactoryBot.create(:admin_user) }
   let(:topic) { FactoryBot.create(:topic) }
   let(:message) { topic.messages.build user: user, content: 'foo' }
   let(:page) { Page.new title: 'First post' }
@@ -60,6 +61,20 @@ describe Drafting::InstanceMethods do
 
       draft = Draft.find(page.draft_id)
       expect(draft.user_id).to eq(nil)
+    end
+
+    it 'should store Draft object for non user' do
+      expect {
+        result = page.save_draft(admin_user)
+
+        expect(result).to eq(true)
+      }.to change(Draft, :count).by(1).and \
+           change(Message, :count).by(0)
+
+      draft = Draft.find(page.draft_id)
+      expect(draft.user).to eq(admin_user)
+      expect(draft.user_type).to eq(admin_user.class.name)
+      expect(draft.user_id).to eq(admin_user.id)
     end
 
     it 'should store extra attributes to Draft' do

--- a/spec/factories/admin_user.rb
+++ b/spec/factories/admin_user.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :admin_user do
+    name { 'Doe' }
+  end
+end

--- a/spec/lib/generators/drafting/migration/migration_generator_spec.rb
+++ b/spec/lib/generators/drafting/migration/migration_generator_spec.rb
@@ -1,0 +1,54 @@
+require 'generator_spec'
+require 'spec_helper'
+require 'generators/drafting/migration/migration_generator'
+
+module Drafting
+  describe MigrationGenerator, type: :generator do
+    root_dir = File.expand_path("../../../../../../tmp", __FILE__)
+    destination root_dir
+
+    describe 'new app' do
+      before :each do
+        prepare_destination
+        run_generator
+      end
+
+      it "creates two installation db migration" do
+        migration_files =
+          Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
+
+        assert_file migration_files[0],
+          /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+        assert_file migration_files[1],
+          /class NonUserDraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+      end
+    end
+
+    describe 'existing app' do
+      before :each do
+        prepare_destination
+        run_generator
+        FileUtils.rm Dir.glob("#{root_dir}/db/migrate/*non_user_drafting_migration.rb")
+
+        migration_files =
+          Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
+        expect(migration_files.count).to eq 1
+        assert_file migration_files[0],
+          /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+
+        run_generator
+      end
+
+      it "creates only one more db migration" do
+        migration_files =
+          Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
+        expect(migration_files.count).to eq 2
+
+        assert_file migration_files[0],
+          /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+        assert_file migration_files[1],
+          /class NonUserDraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+      end
+    end
+  end
+end

--- a/spec/models/admin_user.rb
+++ b/spec/models/admin_user.rb
@@ -1,0 +1,3 @@
+class AdminUser < ActiveRecord::Base
+  validates_presence_of :name
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'drafting'
 require 'generators/drafting/migration/templates/migration.rb'
+require 'generators/drafting/migration/templates/non_user_migration.rb'
 
 require 'factory_bot'
 FactoryBot.find_definitions
@@ -33,6 +34,7 @@ Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].e
 RSpec.configure do |config|
   config.after(:suite) do
     SpecMigration.down
+    NonUserDraftingMigration.down
     DraftingMigration.down
   end
 end
@@ -44,6 +46,7 @@ def setup_db
   ActiveRecord::Migration.verbose = false
 
   DraftingMigration.up
+  NonUserDraftingMigration.up
   SpecMigration.up
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ FactoryBot.find_definitions
 
 # Require some example models
 require 'models/user'
+require 'models/admin_user'
 require 'models/topic'
 require 'models/message'
 require 'models/page'

--- a/spec/support/spec_migration.rb
+++ b/spec/support/spec_migration.rb
@@ -4,6 +4,10 @@ class SpecMigration < Drafting::MIGRATION_BASE_CLASS
       t.string :name, null: false
     end
 
+    create_table :admin_users, force: true do |t|
+      t.string :name, null: false
+    end
+
     create_table :authors, force: true do |t|
       t.string :name, null: false
     end
@@ -44,5 +48,6 @@ class SpecMigration < Drafting::MIGRATION_BASE_CLASS
     drop_table :topics
     drop_table :authors
     drop_table :users
+    drop_table :admin_users
   end
 end


### PR DESCRIPTION
Hi,

I have a use case where I have multiple users (admin_users and project_managers) so I cannot save the drafts under the user namespace. This PR will allow developers to save draft with a non user model.

The gist of this pull request:

1. make 'user' a polymorphic association, so a new `user_type` column of string data type will be added to the drafts table while `user_id` is still preserved to prevent breaking previous versions
2. generate a new migration file to add the `user_type` column
3. generator spec test

USAGE
Developers on current version can just run the migration commands again to generate the second migration file.
```
$ rails g drafting:migration
$ rake db:migrate
```

TODO
if all is good, will add the migration guide to readme