### PR TITLE
Ensure migration files have different prefixes

### DIFF
--- a/lib/generators/drafting/migration/migration_generator.rb
+++ b/lib/generators/drafting/migration/migration_generator.rb
@@ -15,7 +15,12 @@ module Drafting
 
     def self.next_migration_number(dirname)
       if ActiveRecord::Base.timestamped_migrations
-        Time.now.utc.strftime("%Y%m%d%H%M%S")
+        # ensure timestamp of the multiple migration files generated
+        # will be different
+        timestamp = Time.now.utc.strftime("%Y%m%d%H%M%S").to_i
+        timestamp += 1 if current_migration_number(dirname) == timestamp
+
+        timestamp
       else
         "%.3d" % (current_migration_number(dirname) + 1)
       end

--- a/spec/lib/generators/drafting/migration/migration_generator_spec.rb
+++ b/spec/lib/generators/drafting/migration/migration_generator_spec.rb
@@ -7,47 +7,76 @@ module Drafting
     root_dir = File.expand_path("../../../../../../tmp", __FILE__)
     destination root_dir
 
-    describe 'new app' do
-      before :each do
-        prepare_destination
-        run_generator
-      end
+    [
+      {
+        configuration: 'timestamped migrations',
+        timestamped_migrations: true
+      },
+      {
+        configuration: 'numeric prefix migrations',
+        timestamped_migrations: false
+      }
+    ].each do |test_suite|
+      describe test_suite[:configuration] do
+        before :each do
+          ActiveRecord::Base.timestamped_migrations = test_suite[:timestamped_migrations]
+        end
 
-      it "creates two installation db migration" do
-        migration_files =
-          Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
+        describe 'new app' do
+          before :each do
+            prepare_destination
+            run_generator
+          end
 
-        assert_file migration_files[0],
-          /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
-        assert_file migration_files[1],
-          /class NonUserDraftingMigration < Drafting::MIGRATION_BASE_CLASS/
-      end
-    end
+          it "creates two installation db migration" do
+            migration_files =
+              Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
 
-    describe 'existing app' do
-      before :each do
-        prepare_destination
-        run_generator
-        FileUtils.rm Dir.glob("#{root_dir}/db/migrate/*non_user_drafting_migration.rb")
+            assert_equal migration_files.count, 2
 
-        migration_files =
-          Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
-        expect(migration_files.count).to eq 1
-        assert_file migration_files[0],
-          /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+            assert_file migration_files[0],
+              /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+            assert_file migration_files[1],
+              /class NonUserDraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+          end
 
-        run_generator
-      end
+          it "creates migration files of different timestamp" do
+            migration_files =
+              Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
 
-      it "creates only one more db migration" do
-        migration_files =
-          Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
-        expect(migration_files.count).to eq 2
+              migration_no1 = File.basename(migration_files[0]).split("_").first
+              migration_no2 = File.basename(migration_files[1]).split("_").first
 
-        assert_file migration_files[0],
-          /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
-        assert_file migration_files[1],
-          /class NonUserDraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+              assert_not_equal migration_no1, migration_no2
+          end
+        end
+
+        describe 'existing app' do
+          before :each do
+            prepare_destination
+            run_generator
+            FileUtils.rm Dir.glob("#{root_dir}/db/migrate/*non_user_drafting_migration.rb")
+
+            migration_files =
+              Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
+            expect(migration_files.count).to eq 1
+            assert_file migration_files[0],
+              /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+
+            run_generator
+          end
+
+          it "creates only one more db migration" do
+            migration_files =
+              Dir.glob("#{root_dir}/db/migrate/*drafting*.rb").sort
+            expect(migration_files.count).to eq 2
+
+            assert_file migration_files[0],
+              /class DraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+            assert_file migration_files[1],
+              /class NonUserDraftingMigration < Drafting::MIGRATION_BASE_CLASS/
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Hihi,

The previous PR #11 introduced a 'ActiveRecord/DuplicateMigrationVersionError' bug as the 2 migration files generated bear the same prefixes.